### PR TITLE
Redesign projects and detail pages with polished styling

### DIFF
--- a/clx/app/templates/base.html
+++ b/clx/app/templates/base.html
@@ -4,15 +4,42 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>Classifier Experiments</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <script src="https://cdn.tailwindcss.com"></script>
+    <script>
+        tailwind.config = {
+            theme: {
+                extend: {
+                    colors: {
+                        border: '#e5e7eb',
+                        surface: '#ffffff',
+                        muted: '#f9fafb',
+                        'muted-foreground': '#6b7280',
+                    },
+                    fontFamily: {
+                        sans: ['Inter', 'system-ui', '-apple-system', 'sans-serif'],
+                    },
+                }
+            }
+        }
+    </script>
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.1/css/all.min.css">
     <script defer src="https://unpkg.com/alpinejs@3.x.x/dist/cdn.min.js"></script>
 
     <style>
         [x-cloak]{ display: none !important }
+        .scrollable-panel {
+            overflow-y: auto;
+            max-height: calc(100vh - 6.5rem);
+        }
     </style>
 </head>
-<body>
+<body class="font-sans bg-muted text-gray-800 antialiased">
+    <nav class="h-12 border-b border-border flex items-center px-6 bg-surface sticky top-0 z-40">
+        <a href="/" class="text-sm font-semibold text-gray-800 tracking-tight">Classifier Experiments</a>
+    </nav>
     {% block content %}{% endblock %}
 </body>
 </html>

--- a/clx/app/templates/base.html
+++ b/clx/app/templates/base.html
@@ -30,9 +30,9 @@
 
     <style>
         [x-cloak]{ display: none !important }
+        /* Height constrained by parent grid; only overflow-y needed */
         .scrollable-panel {
             overflow-y: auto;
-            max-height: calc(100vh - 6.5rem);
         }
     </style>
 </head>

--- a/clx/app/templates/project_detail.html
+++ b/clx/app/templates/project_detail.html
@@ -48,22 +48,24 @@
                 </span>
             </div>
             <!-- Scrollable document area -->
-            <div class="flex-1 overflow-y-auto p-4 space-y-3">
+            <div class="flex-1 overflow-y-auto p-4">
                 <!-- Loading state -->
                 <div x-show="loading" class="flex items-center justify-center py-12">
                     <span class="text-sm text-gray-400">Loading...</span>
                 </div>
 
                 <!-- Document cards -->
-                <template x-for="doc in documents" :key="doc.id">
-                    <div class="border border-border rounded-lg px-4 py-3 bg-surface hover:border-gray-300 transition-colors cursor-default">
-                        <p class="text-sm text-gray-700 truncate" x-text="doc.text_prefix"></p>
-                    </div>
-                </template>
+                <div x-show="!loading" class="space-y-3">
+                    <template x-for="doc in documents" :key="doc.id">
+                        <div class="border border-border rounded-lg px-4 py-3 bg-surface hover:border-gray-300 transition-colors cursor-default">
+                            <p class="text-sm text-gray-700 truncate" x-text="doc.text_prefix"></p>
+                        </div>
+                    </template>
 
-                <!-- Empty state -->
-                <div x-show="documents.length === 0 && !loading" class="flex items-center justify-center py-12">
-                    <span class="text-sm text-gray-400">No documents yet.</span>
+                    <!-- Empty state -->
+                    <div x-show="documents.length === 0" class="flex items-center justify-center py-12">
+                        <span class="text-sm text-gray-400">No documents yet.</span>
+                    </div>
                 </div>
 
                 <!-- Pagination -->

--- a/clx/app/templates/project_detail.html
+++ b/clx/app/templates/project_detail.html
@@ -1,8 +1,7 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="min-h-screen bg-gray-50"
-     x-data="{
+<div x-data="{
          documents: [],
          page: 1,
          totalPages: 1,
@@ -24,67 +23,75 @@
      }"
      x-init="fetchDocs()">
 
-    <!-- Navbar -->
-    <nav class="bg-white shadow px-6 py-4 flex items-center justify-between">
-        <h1 class="text-lg font-semibold text-gray-800">{{ project.name }}</h1>
-        <a href="/" class="text-blue-600 hover:text-blue-800 text-sm font-medium">
+    <!-- Page navbar (below global nav) -->
+    <nav class="h-14 border-b border-border flex items-center justify-between px-6 bg-surface sticky top-12 z-30">
+        <h1 class="text-sm font-semibold text-gray-800">{{ project.name }}</h1>
+        <a href="/" class="text-xs text-gray-400 hover:text-gray-600 transition-colors">
             <i class="fas fa-arrow-left mr-1"></i> Back to Projects
         </a>
     </nav>
 
     <!-- Three-column layout -->
-    <div class="grid grid-cols-4 gap-6 p-6 max-w-7xl mx-auto">
-        <!-- Left sidebar (placeholder) -->
-        <div class="col-span-1"></div>
+    <div class="grid grid-cols-[280px_1fr_280px] h-[calc(100vh-6.5rem)]">
+        <!-- Left sidebar -->
+        <aside class="border-r border-border p-4 scrollable-panel">
+            <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Filters</h3>
+            <p class="text-sm text-gray-400">No filters configured.</p>
+        </aside>
 
-        <!-- Center content -->
-        <div class="col-span-2">
-            <!-- Document count -->
-            <div class="mb-4 text-gray-600 text-sm">
-                <span x-text="totalCount"></span> document<span x-show="totalCount !== 1">s</span>
+        <!-- Center column -->
+        <div class="flex flex-col">
+            <!-- Pinned doc count header -->
+            <div class="h-10 border-b border-border flex items-center px-4 shrink-0">
+                <span class="text-xs text-muted-foreground">
+                    <span x-text="totalCount.toLocaleString()"></span> document<span x-show="totalCount !== 1">s</span>
+                </span>
             </div>
+            <!-- Scrollable document area -->
+            <div class="flex-1 overflow-y-auto p-4 space-y-3">
+                <!-- Loading state -->
+                <div x-show="loading" class="flex items-center justify-center py-12">
+                    <span class="text-sm text-gray-400">Loading...</span>
+                </div>
 
-            <!-- Loading state -->
-            <div x-show="loading" class="text-center py-8 text-gray-400">
-                Loading...
-            </div>
-
-            <!-- Document list -->
-            <div x-show="!loading" class="bg-white rounded-lg shadow divide-y divide-gray-200">
+                <!-- Document cards -->
                 <template x-for="doc in documents" :key="doc.id">
-                    <div class="px-4 py-3 text-sm text-gray-700">
-                        <span x-text="doc.text_prefix"></span>
-                        <span class="text-gray-400" x-show="doc.text_prefix.length >= 50">...</span>
+                    <div class="border border-border rounded-lg px-4 py-3 bg-surface hover:border-gray-300 transition-colors cursor-default">
+                        <p class="text-sm text-gray-700 truncate" x-text="doc.text_prefix"></p>
                     </div>
                 </template>
-                <div x-show="documents.length === 0 && !loading"
-                     class="px-4 py-8 text-center text-gray-400">
-                    No documents yet.
-                </div>
-            </div>
 
-            <!-- Pagination -->
-            <div x-show="totalPages > 1" class="flex items-center justify-center gap-2 mt-6">
-                <button @click="page--; fetchDocs()"
-                        :disabled="page <= 1"
-                        class="px-3 py-1 rounded border text-sm"
-                        :class="page <= 1 ? 'text-gray-300 border-gray-200 cursor-not-allowed' : 'text-gray-600 border-gray-300 hover:bg-gray-100'">
-                    Previous
-                </button>
-                <span class="text-sm text-gray-600">
-                    Page <span x-text="page"></span> of <span x-text="totalPages"></span>
-                </span>
-                <button @click="page++; fetchDocs()"
-                        :disabled="page >= totalPages"
-                        class="px-3 py-1 rounded border text-sm"
-                        :class="page >= totalPages ? 'text-gray-300 border-gray-200 cursor-not-allowed' : 'text-gray-600 border-gray-300 hover:bg-gray-100'">
-                    Next
-                </button>
+                <!-- Empty state -->
+                <div x-show="documents.length === 0 && !loading" class="flex items-center justify-center py-12">
+                    <span class="text-sm text-gray-400">No documents yet.</span>
+                </div>
+
+                <!-- Pagination -->
+                <div x-show="totalPages > 1" class="flex items-center justify-center gap-3 pt-4 pb-2">
+                    <button @click="page--; fetchDocs()"
+                            :disabled="page <= 1"
+                            class="px-3 py-1.5 text-xs rounded-md border border-border transition-colors"
+                            :class="page <= 1 ? 'text-gray-300 cursor-not-allowed' : 'text-gray-600 hover:border-gray-300 hover:bg-gray-50'">
+                        Previous
+                    </button>
+                    <span class="text-xs text-muted-foreground">
+                        Page <span x-text="page"></span> of <span x-text="totalPages"></span>
+                    </span>
+                    <button @click="page++; fetchDocs()"
+                            :disabled="page >= totalPages"
+                            class="px-3 py-1.5 text-xs rounded-md border border-border transition-colors"
+                            :class="page >= totalPages ? 'text-gray-300 cursor-not-allowed' : 'text-gray-600 hover:border-gray-300 hover:bg-gray-50'">
+                        Next
+                    </button>
+                </div>
             </div>
         </div>
 
-        <!-- Right sidebar (placeholder) -->
-        <div class="col-span-1"></div>
+        <!-- Right sidebar -->
+        <aside class="border-l border-border p-4 scrollable-panel">
+            <h3 class="text-xs font-semibold text-gray-400 uppercase tracking-wider mb-3">Details</h3>
+            <p class="text-sm text-gray-400">Select a document to view details.</p>
+        </aside>
     </div>
 </div>
 {% endblock %}

--- a/clx/app/templates/projects.html
+++ b/clx/app/templates/projects.html
@@ -1,24 +1,26 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="min-h-screen bg-gray-50 p-8" x-data="{ showModal: false, projectName: '' }">
+<div class="min-h-screen p-8" x-data="{ showModal: false, projectName: '' }">
     <div class="max-w-6xl mx-auto">
-        <h1 class="text-3xl font-bold text-gray-800 mb-8">Projects</h1>
+        <div class="border-b border-border pb-6 mb-8">
+            <h1 class="text-2xl font-semibold text-gray-900">Projects</h1>
+        </div>
 
         <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
             {% for project in projects %}
             <a href="/projects/{{ project.id }}/"
-               class="block bg-white rounded-lg shadow hover:shadow-md transition-shadow p-6">
-                <h2 class="text-xl font-semibold text-gray-700">{{ project.name }}</h2>
+               class="block bg-white rounded-lg border border-border hover:border-gray-300 transition-colors p-6">
+                <h2 class="text-lg font-medium text-gray-800">{{ project.name }}</h2>
             </a>
             {% endfor %}
 
             <!-- New Project Card -->
             <button @click="showModal = true"
-                    class="flex items-center justify-center bg-white rounded-lg shadow hover:shadow-md transition-shadow p-6 border-2 border-dashed border-gray-300 text-gray-400 hover:text-gray-600 hover:border-gray-400 cursor-pointer">
+                    class="flex items-center justify-center bg-white rounded-lg border border-dashed border-gray-200 p-6 text-gray-400 hover:text-gray-500 hover:border-gray-300 transition-colors cursor-pointer">
                 <div class="text-center">
-                    <i class="fas fa-plus text-3xl mb-2"></i>
-                    <p class="text-lg font-medium">New Project</p>
+                    <i class="fas fa-plus text-2xl mb-2"></i>
+                    <p class="text-base font-medium">New Project</p>
                 </div>
             </button>
         </div>
@@ -26,11 +28,11 @@
 
     <!-- New Project Modal -->
     <div x-show="showModal" x-cloak
-         class="fixed inset-0 z-50 flex items-center justify-center bg-black bg-opacity-50"
+         class="fixed inset-0 z-50 flex items-center justify-center bg-black/50"
          @keydown.escape.window="showModal = false">
-        <div class="bg-white rounded-lg shadow-xl p-6 w-full max-w-md"
+        <div class="bg-white rounded-xl border border-border p-6 w-full max-w-md"
              @click.outside="showModal = false">
-            <h2 class="text-xl font-semibold text-gray-800 mb-4">Create New Project</h2>
+            <h2 class="text-lg font-semibold text-gray-800 mb-4">Create New Project</h2>
             <form @submit.prevent="
                 fetch('/api/projects/', {
                     method: 'POST',
@@ -48,16 +50,16 @@
                        type="text"
                        x-model="projectName"
                        required
-                       class="w-full border border-gray-300 rounded-md px-3 py-2 mb-4 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                       class="w-full border border-gray-300 rounded-lg px-3 py-2 mb-4 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:border-gray-900"
                        placeholder="Enter project name">
                 <div class="flex justify-end gap-3">
                     <button type="button"
                             @click="showModal = false"
-                            class="px-4 py-2 text-gray-600 hover:text-gray-800">
+                            class="px-4 py-2 text-sm text-gray-500 hover:text-gray-700">
                         Cancel
                     </button>
                     <button type="submit"
-                            class="px-4 py-2 bg-blue-600 text-white rounded-md hover:bg-blue-700">
+                            class="px-4 py-2 text-sm bg-gray-900 text-white rounded-lg hover:bg-gray-800">
                         Create
                     </button>
                 </div>


### PR DESCRIPTION
<sub>🤖 Posted by my coding agent</sub>

## Summary

Closes #5 — full styling pass across the three templates to establish a clean, minimal, professional design language.

### Changes

- **`base.html`**: Added Tailwind config with design tokens (consistent border/surface/muted colors), Inter font via Google Fonts, a shared sticky global nav bar ("Classifier Experiments"), and a `.scrollable-panel` CSS utility for independently scrollable panels.

- **`projects.html`**: Replaced shadow-based card hover with subtle border transitions. Refined the "New Project" card (thinner dashed border, softer hover). Polished the modal with `rounded-xl`, neutral color scheme (`bg-gray-900` primary button instead of blue), ghost-style cancel button, and `bg-black/50` overlay.

- **`project_detail.html`**: Major structural rework:
  - Page-level navbar pinned below global nav (`sticky top-12`)
  - Three-column layout with fixed 280px sidebars using CSS grid (`grid-cols-[280px_1fr_280px]`)
  - Bordered, independently scrollable sidebar panels with placeholder content
  - Pinned document count header with `toLocaleString()` formatting
  - Individual document cards (border-based, hover state, `truncate` for text overflow)
  - Refined pagination controls matching the new design language

### Design principles applied
- Whitespace over decoration, thin borders over shadows
- Consistent spacing and typography hierarchy
- Sidebars and center column as clearly delineated, independently scrollable panels
- Card layout ready for richer content later

No backend or model changes.